### PR TITLE
docs: migration plan, spec, and changelog

### DIFF
--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -1,0 +1,184 @@
+# gianfaye.com — Implementation Plan
+
+> See [SPEC.md](./SPEC.md) for what's being built and why.
+> See [changelogs/](./changelogs/) for what's been done so far.
+
+The migration runs in 7 phases. Development happens in a `site-v2/` subdirectory so the existing Gatsby code remains untouched and `gianfaye.com` keeps serving the old site until **Phase 6** (the final swap).
+
+---
+
+## Phase 0 — Repo & deploy scaffold
+
+**Goal:** Prove the deploy pipeline works end-to-end before writing real code.
+
+- Create `site-v2/` directory at repo root
+- Scaffold Astro: `npm create astro@latest -- --template minimal --typescript strict`
+- Configure `astro.config.mjs` with `site: 'https://gianfaye.com'`, `output: 'static'`
+- Add integrations: `@astrojs/sitemap`, `@astrojs/mdx`
+- Add Tailwind v4 via `@tailwindcss/postcss` (the Vite plugin is incompatible with Astro 6's Rolldown bundler)
+- Add `public/CNAME` and `public/.nojekyll`
+- Add `.github/workflows/build-check.yml` at repo root for PR build verification
+- Stage `site-v2/.github/workflows/deploy.yml` (inert until Phase 6)
+- Pin Node via `.nvmrc` (LTS 22)
+
+**Verification:** Open a draft PR, confirm `Build check (site-v2)` passes. Don't merge.
+
+---
+
+## Phase 1 — Content collection schemas + migration
+
+**Goal:** All 37 posts + 12 projects load into Astro Content Collections.
+
+- Define `src/content.config.ts` with collection schemas (see [SPEC.md §3](./SPEC.md#3-content-schemas))
+- Copy `www/content/posts/` → `site-v2/src/content/posts/`
+- Copy `www/content/projects/` → `site-v2/src/content/projects/`
+- Copy `www/content/topics/topics.yml`, `works/works.yml`, `clients/clients.yml`
+- Adjust frontmatter where needed (verify date parsing, topic comma-handling)
+
+**Verification:** `astro check` passes; `astro build` outputs all 37 posts + 12 projects without errors.
+
+---
+
+## Phase 2 — Layout, header, footer, dark mode
+
+**Goal:** Site chrome matches existing look.
+
+- `src/layouts/BaseLayout.astro` — `<html>`, head, header, footer, slot
+- `src/layouts/ArticleLayout.astro` — extends BaseLayout, adds sticky title aside, progress bar, share, Disqus
+- Migrate fonts from `www/static/fonts/` → `site-v2/public/fonts/`
+- Tailwind theme tokens — colors and font stacks extracted from existing theme
+- Dark mode — `prefers-color-scheme` + localStorage toggle, vanilla TS, no flicker (inline script in `<head>`)
+- Header with sticky behavior + scroll-aware shadow
+- Mobile hamburger menu
+- Footer with social icons
+
+**Verification:** Visual diff against archived Gatsby site running locally.
+
+---
+
+## Phase 3 — Listing & detail pages
+
+- Home page (`index.astro`): hero, typing animation, recent posts grid, recent projects grid, client swiper gallery
+- Blog list with pagination (Astro `paginate()` API)
+- Blog post template (article layout, MDX rendering, hero image, share, Disqus, next/prev)
+- Projects list (grid)
+- Project template
+- Topics index + per-topic archive
+- Works index + per-work archive
+- About, timeline, terms, privacy, 404
+
+**Verification:** Click through every page in the local dev server. Compare to the old site rendered from `archive/gatsby-v2`.
+
+---
+
+## Phase 4 — Custom features
+
+- Reading progress bar — vanilla JS scroll listener, ~20 LoC
+- Particles animation on about page — `tsparticles` v3 with the slim engine bundle
+- Typing animation on home — custom TS, ~30 LoC
+- Image zoom — `medium-zoom` initialized client-side
+- Client swiper — Swiper v11 with module imports
+- Skills grid — static HTML with skill icons from `www/static/`
+- Code highlighting — Shiki theme tuned to match Prism setup
+
+**Verification:** Each interactive element works in Chrome, Safari, Firefox, mobile Safari.
+
+---
+
+## Phase 5 — SEO, RSS, sitemap, analytics, Disqus
+
+- Shared `<SEO>` component for meta/OG/Twitter tags
+- JSON-LD structured data for posts and projects
+- `@astrojs/rss` route for `/rss.xml` (posts) and `/projects-rss.xml` (projects)
+- `@astrojs/sitemap` integration
+- Create new GA4 property; add tracking script with consent-aware loading
+- Disqus embed in article template using existing shortname
+- `robots.txt`
+
+**Verification:** Lighthouse score ≥95 across performance/SEO/accessibility/best-practices. RSS validates at validator.w3.org. Sitemap loads. Analytics fires (real-time check).
+
+---
+
+## Phase 6 — Final swap + production deploy
+
+**Goal:** Replace Gatsby code at repo root with the new Astro site.
+
+- Delete from repo root: `www/`, `@gianfaye/`, `lerna.json`, `package.json`, `yarn.lock`, `.commitlintrc.yml` (Gatsby-era)
+- Move all of `site-v2/*` to repo root
+- Update `.gitignore` for Astro (`dist/`, `.astro/`, `node_modules/`)
+- Update `.github/workflows/deploy.yml` to build from root
+- Final test: `npm run build` from repo root, deploy to `gh-pages`
+- DNS sanity check: `gianfaye.com` resolves and serves the new site
+
+**Verification:** Site loads at `https://gianfaye.com`. Spot-check 5 random old blog post URLs to confirm no broken links.
+
+---
+
+## Timeline
+
+Estimates assume part-time work (a few hours per session). Each phase is a natural commit boundary.
+
+| Phase | Description | Effort | Calendar estimate |
+|---|---|---|---|
+| 0 | Repo scaffold + deploy pipeline | ~2 h | Day 1 |
+| 1 | Content schemas + migration | ~3 h | Day 2 |
+| 2 | Layout, header, footer, dark mode | ~6 h | Days 3–4 |
+| 3 | Listing & detail pages | ~8 h | Days 5–7 |
+| 4 | Custom features | ~5 h | Day 8 |
+| 5 | SEO, RSS, sitemap, analytics, Disqus | ~3 h | Day 9 |
+| 6 | Final swap + production deploy | ~2 h | Day 10 |
+| **Total** | | **~29 h** | **~2 weeks part-time** |
+
+Each phase ends with a commit on a feature branch, mergeable to `master` independently. Phase 6 is the only phase that visibly changes `gianfaye.com` for real visitors.
+
+---
+
+## Maintenance Plan
+
+The Gatsby site failed because nothing checked it for years. The new plan automates dependency checks and pins a recurring manual review.
+
+### Automated (continuous)
+- **Dependabot** (`.github/dependabot.yml`) — daily checks for npm + GitHub Actions; auto-PRs for security patches and minor/patch versions
+- **GitHub security advisories** — enabled at repo level
+- **Build status** — every PR runs `astro check` + `astro build` to catch breakage before merge
+
+### Quarterly (every 3 months — first Monday of January, April, July, October)
+A `MAINTENANCE.md` file at repo root will document the checklist:
+1. Run `npm outdated` and review major version bumps
+2. Read Astro release notes since last check (https://github.com/withastro/astro/releases)
+3. Review Dependabot's open PRs and merge or close
+4. Run `npm audit` and resolve high/critical findings
+5. Test build locally, deploy a staging preview
+6. Update `MAINTENANCE.md` log with date + notes
+
+### Annually (every January)
+1. Evaluate Astro major version migration (e.g., v6 → v7) — read migration guide, plan upgrade
+2. Audit content: archive/unpublish posts that are no longer accurate
+3. Renew domain registration check
+4. Refresh GA4 property settings, review traffic
+5. Run a full Lighthouse audit and address regressions
+
+### Reminders
+A scheduled GitHub Actions workflow opens a "Quarterly review" issue on the first Monday of each quarter. Set up after Phase 6.
+
+### Pinning strategy
+- Use `^` ranges for Astro and integrations (auto-update minor/patch)
+- Lock `engines.node` in `package.json` to current LTS (e.g., `>=22.0.0`)
+- Keep `.nvmrc` in sync with CI Node version
+
+---
+
+## Verification (end-to-end test, post-Phase-6)
+
+1. **Build & type-check pass:** `npm run build` + `astro check` exit 0 with no errors or warnings
+2. **All URLs from the old site resolve:** Spot-check 10 random `/blog/:slug` and `/project/:slug` URLs return 200
+3. **RSS feed validates:** Paste `https://gianfaye.com/rss.xml` into https://validator.w3.org/feed/
+4. **Sitemap valid:** `curl https://gianfaye.com/sitemap-index.xml` returns valid XML; submit to Google Search Console
+5. **Lighthouse audit:** Run on home, blog list, a blog post, project list, about — all scores ≥95
+6. **GA4 fires:** Open the site, check GA4 real-time view shows the visit
+7. **Disqus loads:** Open any blog post, scroll to comments, comments thread renders
+8. **Dark mode toggle persists:** Toggle, refresh, mode is retained
+9. **Mobile responsive:** Test home, blog post, about, timeline at iPhone SE viewport (375px)
+10. **DNS:** `dig gianfaye.com` shows GitHub Pages IPs; `https://gianfaye.com` serves the new site without redirect loops
+
+If all 10 pass, the migration is complete. `archive/gatsby-v2` becomes a permanent reference branch (do not delete).

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1,0 +1,140 @@
+# gianfaye.com — Site Specification
+
+## Context
+
+`gianfaye.com` is a personal portfolio + blog hosted free on **GitHub Pages** from this repo (the User Pages repo `gianfaye/gianfaye.github.com`), with a custom domain mapped via `CNAME`.
+
+The site was originally built on Jekyll, migrated to Gatsby v2 (Novela theme) in 2020, and is now being rebuilt on **Astro 6.x** in 2026 because the Gatsby v2 stack is unmaintainable: build is broken (`narative/gatsby-theme#249`), dependencies are 3+ major versions behind, and many packages are deprecated. Astro produces static HTML output that survives even if maintenance lapses for years, was acquired by Cloudflare (Jan 2026), and has first-class MDX support.
+
+Old Gatsby code is preserved on the `archive/gatsby-v2` branch.
+
+---
+
+## 1. Stack
+
+- **Framework:** Astro 6.1.x (latest stable, April 2026)
+- **Language:** TypeScript (`strict`)
+- **Styling:** Tailwind CSS v4 via `@tailwindcss/postcss` (the Vite plugin is incompatible with Astro 6's Rolldown bundler), with custom theme tokens to recreate existing colors, fonts (Gotham, Sentinel, vger), and spacing
+- **Content:** Astro Content Collections (Zod schemas) + MDX
+- **Image handling:** Astro built-in `<Image>` component with Sharp
+- **Hosting:** GitHub Pages (free) via GitHub Actions → `gh-pages` branch
+- **Domain:** `gianfaye.com` via `CNAME` file
+- **Package manager:** npm (drop Yarn + Lerna; single project, no workspace)
+- **Node:** pinned to LTS 22 via `.nvmrc`
+
+---
+
+## 2. Pages & Routes
+
+All existing URLs preserved for SEO/backlinks.
+
+| Route | Source | Notes |
+|---|---|---|
+| `/` | `src/pages/index.astro` | Home: hero, typing animation, recent posts, recent projects, client gallery |
+| `/blog/` | `src/pages/blog/index.astro` | Paginated list (10/page) |
+| `/blog/[slug]/` | `src/pages/blog/[slug].astro` | Article template |
+| `/project/` | `src/pages/project/index.astro` | Projects grid |
+| `/project/[slug]/` | `src/pages/project/[slug].astro` | Project template |
+| `/topics/` | `src/pages/topics/index.astro` | Topic taxonomy listing |
+| `/topics/[topic]/` | `src/pages/topics/[topic].astro` | Topic archive |
+| `/works/` | `src/pages/works/index.astro` | Work types listing |
+| `/works/[work]/` | `src/pages/works/[work].astro` | Work type archive |
+| `/about/` | `src/pages/about.astro` | About page (particles, skills grid, interests) |
+| `/timeline/` | `src/pages/timeline.astro` | Career timeline |
+| `/terms/` | `src/pages/terms.astro` | Terms of service |
+| `/privacy/` | `src/pages/privacy.astro` | Privacy policy |
+| `/404.html` | `src/pages/404.astro` | Not found |
+| `/rss.xml` | `src/pages/rss.xml.ts` | RSS feed (`@astrojs/rss`) |
+| `/sitemap-index.xml` | `@astrojs/sitemap` integration | Auto-generated |
+
+---
+
+## 3. Content Schemas
+
+### `src/content/posts/` — 37 entries
+Migrated from `www/content/posts/` (Gatsby).
+
+```ts
+{
+  title: string,
+  slug?: string,           // Optional override; defaults to filename
+  topic: string,           // Comma-separated string preserved as-is
+  date: Date,
+  hero: image schema,      // Co-located ./images/*.jpg
+  excerpt: string,
+  categories?: string[],
+}
+```
+
+### `src/content/projects/` — 12 entries
+Migrated from `www/content/projects/`.
+
+```ts
+{
+  title: string,
+  slug?: string,
+  work: enum('Website', 'Landing Page', 'Print', 'Software'),
+  client?: string,
+  date: Date,
+  hero: image schema,
+  excerpt: string,
+  categories?: string[],
+}
+```
+
+### Taxonomies (YAML, migrated as-is)
+- `src/content/topics/topics.yml` — 18 topics
+- `src/content/works/works.yml` — 5 work types
+- `src/content/clients/clients.yml` — 18 clients
+
+---
+
+## 4. Visual & Functional Parity
+
+Goal: **recreate the existing look as closely as possible** (not a redesign).
+
+- **Typography:** Gotham (body), Sentinel (headings), vger (display) — fonts copied from `www/static/fonts/`
+- **Color palette + dark mode toggle** — extracted from `@gianfaye/gatsby-theme/src/gatsby-plugin-theme-ui/colors.ts`
+- **Header** — sticky, with logo, nav (Blog, Projects, About, Timeline), dark mode toggle, mobile hamburger
+- **Footer** — social links (GitHub, LinkedIn, Twitter, StackOverflow, Email)
+- **Reading progress bar** — sticky on article pages (vanilla JS)
+- **Article layout** — sticky title aside, share buttons (Twitter, Facebook, LinkedIn, copy link), next/prev navigation, Disqus comments
+- **Code highlighting** — Shiki (Astro built-in, replaces Prism)
+- **Particles animation (about page)** — `tsparticles` v3 (modern successor of the version in use)
+- **Typing animation (home)** — vanilla TS implementation (~30 LoC, replaces deprecated `react-typist`)
+- **Client gallery (home)** — Swiper v11
+- **Skills grid (about)** — 12 skill icons (HTML5, CSS3, React, TypeScript, ES6/JS, Angular, Redux, UX, UI, etc.)
+- **Image zoom on click** — `medium-zoom` (vanilla, replaces `react-medium-image-zoom`)
+
+---
+
+## 5. Integrations
+
+| Integration | Implementation | Notes |
+|---|---|---|
+| **Google Analytics** | Direct GA4 script in base layout, optionally lazy-loaded | Upgrade from UA-36995024-1 to a new GA4 property |
+| **Disqus comments** | Vanilla embed in article template | Reuse existing Disqus shortname |
+| **RSS** | `@astrojs/rss` | Routes: `/rss.xml`, `/projects-rss.xml` |
+| **Sitemap** | `@astrojs/sitemap` | Auto-generated |
+| **Mailchimp** | **Dropped** | Newsletter signup removed |
+
+---
+
+## 6. SEO
+
+- Meta tags per page (title, description, OG image, Twitter card) via shared `<SEO>` Astro component
+- Canonical URLs
+- Structured data (JSON-LD) for blog posts (Article schema) and projects (CreativeWork schema)
+- `robots.txt` and `sitemap-index.xml`
+
+---
+
+## 7. Hosting Constraints
+
+The site MUST be deployable to GitHub Pages with no paid services. This means:
+- Static output only — no SSR, no API routes, no on-demand image optimization
+- `CNAME` file required at build output root
+- `.nojekyll` file required to prevent Jekyll processing
+- Single-repo architecture (User Pages repo serves apex domain)
+
+Any framework or feature change must respect these constraints. Paid hosting (Vercel, Netlify) is out of scope.

--- a/docs/changelogs/2026-04-25_CHANGELOG.md
+++ b/docs/changelogs/2026-04-25_CHANGELOG.md
@@ -1,0 +1,54 @@
+# Changelog — 2026-04-25
+
+## Migration kickoff: Gatsby → Astro
+
+### Decisions
+- Audited current Gatsby v2 monorepo. Build broken (per inline note in `www/package.json` referencing `narative/gatsby-theme#249`). Dependencies 3+ majors behind: Gatsby v2 → v5, React 16 → 18, Theme UI 0.2 → 0.16. Multiple deprecated packages (`@emotion/core`, `babel-plugin-emotion`, `gatsby-image`, `gatsby-plugin-google-analytics`, `request`, `react-typist`).
+- Decided to **rebuild rather than incrementally upgrade** — the gap between Gatsby v2 and current is roughly equivalent to a fresh build, with all the friction of fighting old APIs.
+- Evaluated Next.js vs Astro. Chose **Astro** for: purpose-built for content sites, first-class MDX, static HTML output (essential for free GitHub Pages hosting), 50K+ stars, recently acquired by Cloudflare (Jan 2026) signaling long-term commitment.
+- Confirmed Astro 6.1.x is production-stable. Ecosystem support verified for: GitHub Pages deploy, sitemap, RSS, GA4, Tailwind v4.
+- Site stays on the existing User Pages repo (`gianfaye/gianfaye.github.com`) with `CNAME` for `gianfaye.com`. Single repo, no source/deploy split.
+
+### Scope locked in
+- **Design:** Recreate existing look as closely as possible (not a redesign).
+- **Content:** Migrate all 37 blog posts + 12 projects as-is, no curation.
+- **URLs:** Preserve `/blog/:slug` and `/project/:slug` for SEO/backlinks.
+- **Integrations:** Drop Mailchimp. Keep Disqus. Keep analytics (upgrade UA → GA4).
+- **Repo strategy:** Develop in `site-v2/` subdir; final phase deletes Gatsby files and moves Astro to root.
+- See [`docs/SPEC.md`](../SPEC.md) and [`docs/PLAN.md`](../PLAN.md).
+
+### Maintenance
+- Quarterly manual review (first Monday of Jan/Apr/Jul/Oct) + Dependabot automation. Explicit goal: avoid the Gatsby-rot pattern.
+
+---
+
+## Phase 0 — Repo & deploy scaffold ✅
+
+**Branch:** `feat/astro-phase-0` ([PR #7](https://github.com/gianfaye/gianfaye.github.com/pull/7), draft)
+
+### Done
+- Archived old Gatsby site to branch `archive/gatsby-v2`.
+- Scaffolded Astro 6.1.9 in `site-v2/` (TypeScript strict, minimal template).
+- Installed integrations: `@astrojs/mdx`, `@astrojs/sitemap`, `@astrojs/rss`.
+- Wired up Tailwind CSS v4 via `@tailwindcss/postcss`.
+- Created `public/CNAME` (gianfaye.com) and `public/.nojekyll`.
+- Added `.github/workflows/build-check.yml` at repo root for PR build verification.
+- Staged inert `site-v2/.github/workflows/deploy.yml` for Phase 6 swap.
+- Pinned Node to LTS 22 via `site-v2/.nvmrc`.
+
+### Deviation from plan
+- Plan specified `@tailwindcss/vite`, but it failed to build under Astro 6's Rolldown-Vite bundler with `Missing field 'tsconfigPaths' on BindingViteResolvePluginConfig.resolveOptions`. Switched to `@tailwindcss/postcss` — produces identical Tailwind v4 output, no functional difference.
+
+### Verification
+- Local: `npm run build` → ✅ (1 page in 901ms, sitemap generated, CNAME copied to dist)
+- Local: `npx astro check` → ✅ 0 errors / 0 warnings / 0 hints
+- CI: `Build check (site-v2)` workflow → ✅ passing in 24s on PR #7
+
+### CI fix during Phase 0
+- First CI run failed with `Missing: @emnapi/runtime@1.10.0 from lock file` — Sharp's cross-platform optional native dependencies don't all serialize into the lock when generated on macOS.
+- Resolved by switching CI from `npm ci` to `npm install --no-audit --no-fund` (more forgiving of platform-specific Sharp transitive deps) and pinning Node to 22 LTS via `.nvmrc`.
+
+---
+
+## Up next
+- Phase 1: Content collection schemas + migration of 37 posts + 12 projects.


### PR DESCRIPTION
Adds a `docs/` directory with the long-form migration documentation:

- `docs/SPEC.md` — what we're building (stack, pages, content schemas, visual parity, integrations, hosting constraints)
- `docs/PLAN.md` — phased implementation plan, timeline, and maintenance plan
- `docs/changelogs/2026-04-25_CHANGELOG.md` — today's events: kickoff decisions and Phase 0 completion

Independent of the Phase 0 PR (#7) — these are documentation-only and safe to merge to master directly.